### PR TITLE
[PR] Site and page header support

### DIFF
--- a/css/admin-edit-issue.css
+++ b/css/admin-edit-issue.css
@@ -1,11 +1,11 @@
 .ttfmake-menu-list-item {
-	width: calc(100% / 3);
+	width: 25%;
 }
 
 @media screen and (min-width: 1160px) {
 
 	.ttfmake-menu-list-item {
-		width: calc(100% / 3);
+		width: 25%;
 	}
 }
 
@@ -26,6 +26,10 @@
 	margin-bottom: 0;
 	min-height: 30px;
 	padding: 0;
+}
+
+.ttfmake-titlediv {
+	margin-bottom: 0;
 }
 
 .ttfmake-section-wsuwp_issue_halves .wsuwp-spine-builder-column-position-1,

--- a/css/src/admin-edit-issue.css
+++ b/css/src/admin-edit-issue.css
@@ -1,11 +1,11 @@
 .ttfmake-menu-list-item {
-	width: calc(100% / 3);
+	width: 25%;
 }
 
 @media screen and (min-width: 1160px) {
 
 	.ttfmake-menu-list-item {
-		width: calc(100% / 3);
+		width: 25%;
 	}
 }
 
@@ -26,6 +26,10 @@
 	margin-bottom: 0;
 	min-height: 30px;
 	padding: 0;
+}
+
+.ttfmake-titlediv {
+	margin-bottom: 0;
 }
 
 .ttfmake-section-wsuwp_issue_halves .wsuwp-spine-builder-column-position-1,

--- a/includes/issue-post-type.php
+++ b/includes/issue-post-type.php
@@ -76,6 +76,7 @@ function register_builder_support() {
  * Removes sections defined for the default implemenation of the page builder.
  *
  * @since 0.0.1
+ * @since 0.0.2 Re-enabled the Header section.
  */
 function remove_builder_sections( $current_screen ) {
 	if ( slug() !== $current_screen->id ) {
@@ -88,7 +89,6 @@ function remove_builder_sections( $current_screen ) {
 	ttfmake_remove_section( 'wsuwpsidebarright' );
 	ttfmake_remove_section( 'wsuwpthirds' );
 	ttfmake_remove_section( 'wsuwpquarters' );
-	ttfmake_remove_section( 'wsuwpheader' );
 	ttfmake_remove_section( 'banner' );
 }
 

--- a/includes/issue-post-type.php
+++ b/includes/issue-post-type.php
@@ -417,6 +417,7 @@ function admin_enqueue_scripts( $hook ) {
  * Adds the post staging meta box used by the issue content type.
  *
  * @since 0.0.1
+ * @since 0.0.2 Added the "spine-main-header" metabox.
  */
 function add_post_stage_meta_box() {
 	add_meta_box(
@@ -425,6 +426,13 @@ function add_post_stage_meta_box() {
 		__NAMESPACE__ . '\\display_issue_posts_meta_box',
 		slug(),
 		'side'
+	);
+
+	add_meta_box(
+		'spine-main-header',
+		'Spine Main Header',
+		array( new \Spine_Main_Header(), 'display_main_header_meta_box' ),
+		slug()
 	);
 }
 

--- a/includes/wsuwp-issue-builder.php
+++ b/includes/wsuwp-issue-builder.php
@@ -12,7 +12,7 @@ add_action( 'after_setup_theme', __NAMESPACE__ . '\\bootstrap' );
  * @return string The plugin version number.
  */
 function version() {
-	return '0.0.1';
+	return '0.0.2';
 }
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "wsuwp-plugin-issue-builder",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wsuwp-plugin-issue-builder",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/washingtonstateuniversity/wsuwp-plugin-issue-builder"

--- a/plugin.php
+++ b/plugin.php
@@ -1,7 +1,7 @@
 <?php
 /*
 Plugin Name: WSUWP Issue Builder
-Version: 0.0.1
+Version: 0.0.2
 Description: A WordPress plugin for displaying specific collections of posts.
 Author: washingtonstateuniversity, philcable
 Author URI: https://web.wsu.edu/


### PR DESCRIPTION
Per feedback from Joyce, this will allow users to provide a page title and override the spine sub and sub headers for Issues.